### PR TITLE
link formatting correction in 2020-12-03-docs.md

### DIFF
--- a/src/leiningen/new/cryogen/content/md/posts/2020-12-03-docs.md
+++ b/src/leiningen/new/cryogen/content/md/posts/2020-12-03-docs.md
@@ -34,7 +34,7 @@ A new site can be created using the Cryogen template as follows:
 lein new cryogen my-blog
 ```
 
-or, alternatively, using `clj-new as a tool`](https://github.com/seancorfield/clj-new#installation-as-a-tool):
+or, alternatively, using [`clj-new as a tool`](https://github.com/seancorfield/clj-new#installation-as-a-tool):
 
 ```
 clojure -Ttools install com.github.seancorfield/clj-new '{:git/tag "v1.2.362"}' :as clj-new # update to latest!


### PR DESCRIPTION
There's a broken link in the sample post in content/md/posts/2020-12-03-docs.md file. This should fix that.